### PR TITLE
Improve performance of Bitmap generation

### DIFF
--- a/android/src/main/java/net/glxn/qrgen/android/MatrixToImageWriter.java
+++ b/android/src/main/java/net/glxn/qrgen/android/MatrixToImageWriter.java
@@ -41,14 +41,16 @@ public class MatrixToImageWriter {
 	 * @return {@link Bitmap} representation of the input
 	 */
 	public static Bitmap toBitmap(BitMatrix matrix, MatrixToImageConfig config) {
-        int width = matrix.getWidth();
-        int height = matrix.getHeight();
-        int[] pixels = new int[width * height];
+        final int onColor = config.getPixelOnColor();
+        final int offColor = config.getPixelOffColor();
+        final int width = matrix.getWidth();
+        final int height = matrix.getHeight();
+        final int[] pixels = new int[width * height];
 
         for (int y = 0; y < height; y++) {
             int offset = y * width;
             for (int x = 0; x < width; x++) {
-                pixels[offset + x] = matrix.get(x, y) ? config.getPixelOnColor() : config.getPixelOffColor();
+                pixels[offset + x] = matrix.get(x, y) ? onColor : offColor;
             }
         }
 


### PR DESCRIPTION
On a virtual android device, QR Code generation is really slow (up to 17 seconds). After further investigation, I found that the method responsible for such slowness is MatrixToImageWriter.toBitmap(...) .

I tried to replace the code with this one adapted from Zxing [here](https://github.com/zxing/zxing/blob/master/android/src/com/google/zxing/client/android/encode/QRCodeEncoder.java):

``` java
        int BLACK = 0xFF000000;
        int WHITE = 0xFFFFFFFF;
        int width = bitMatrix.getWidth();
        int height = bitMatrix.getHeight();
        int[] pixels = new int[width * height];

        // All are 0, or black, by default
        for (int y = 0; y < height; y++) {
            int offset = y * width;
            for (int x = 0; x < width; x++) {
                pixels[offset + x] = bitMatrix.get(x, y) ? BLACK : WHITE;
            }
        }

        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
        bitmap.setPixels(pixels, 0, width, 0, 0, width, height);
        return bitmap;
```

... and it's 40 times faster !
Fore reference, I also tried another one, adapted from [here](http://androiducl.blogspot.fr/2012/04/bitmap-in-zxing.html): 

``` java
        int BLACK = 0xFF000000;
        int WHITE = 0xFFFFFFFF;
        int width = matrix.getWidth();
        int height = matrix.getHeight();
        int[] pixels = new int[width * height];

        for (int y = 0; y < height; y++) {
            int offset = y * width;
            for (int x = 0; x < width; x++) {
                pixels[offset + x] = bitMatrix.get(x, y) ? BLACK : WHITE;
            }
        }

        Bitmap image = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
        image.setPixels(pixels, 0, width, 0, 0, width, height);
        return image;
```

It's 'only' 6 times faster. 
