### PR TITLE
Fixed QRCode Generation on android

### DIFF
--- a/android/src/main/java/net/glxn/qrgen/android/BitmapIO.java
+++ b/android/src/main/java/net/glxn/qrgen/android/BitmapIO.java
@@ -24,12 +24,11 @@ public class BitmapIO {
 	
 	public static boolean write(Bitmap image, String type, File file) throws IOException {
 		OutputStream stream = null;
-		try{
+		try {
 			stream = new FileOutputStream(file);
 			return write(image, type, stream);
-			
 		} catch (IOException ioe) {
-			
+			throw ioe;
 		} finally {
 			if(stream != null) {
 				stream.flush();
@@ -37,6 +36,5 @@ public class BitmapIO {
 			}
 		}
 		
-		return false;
 	}
 }

--- a/android/src/main/java/net/glxn/qrgen/android/MatrixToImageConfig.java
+++ b/android/src/main/java/net/glxn/qrgen/android/MatrixToImageConfig.java
@@ -38,11 +38,7 @@ public class MatrixToImageConfig {
 	}
 
 	Bitmap.Config getBufferedImageColorModel() {
-//		return 0;
-		// Use faster BINARY if colors match default
-		//Represents an image with 8-bit RGBA color components packed into integer pixels.
-		//Represents an opaque byte-packed 1, 2, or 4 bit image.
-		return onColor == BLACK && offColor == WHITE ? Bitmap.Config.ALPHA_8: Bitmap.Config.ARGB_8888;
-		//return onColor == BLACK && offColor == WHITE ? Bitmap.TYPE_BYTE_BINARY: BufferedImage.TYPE_INT_RGB;
+		//On Android the ALPHA_8 model doesn't work, results in empty files and therefore IOExceptions
+		return Bitmap.Config.ARGB_8888;
 	}
 }


### PR DESCRIPTION
After the last changes to android module my example project crashed, as the created file was of size 0, because the `Bitmap.Config.ALPHA_8` seems not to work on android. I've tested on an emulator with android api 17 (4.2 Jelly Bean). Will try later latest kitkat release to see if there are any differences between api versions.
