### PR TITLE
Add maven central badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/kenglxn/QRGen.png?branch=master)](https://travis-ci.org/kenglxn/QRGen)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/net.glxn/qrgen/badge.svg)](https://maven-badges.herokuapp.com/maven-central/net.glxn/qrgen)
 
 [![Donate](https://rawgithub.com/twolfson/gittip-badge/0.2.0/dist/gittip.png)](https://www.gittip.com/kenglxn/)
 


### PR DESCRIPTION
Added maven central badge. See https://github.com/jirutka/maven-badges for details.
