### PR TITLE
Cleanup svg and bitmap terminal operators

### DIFF
--- a/android/src/main/java/net/glxn/qrgen/android/QRCode.java
+++ b/android/src/main/java/net/glxn/qrgen/android/QRCode.java
@@ -1,10 +1,13 @@
 package net.glxn.qrgen.android;
 
 import android.graphics.Bitmap;
+import com.google.zxing.EncodeHintType;
 import com.google.zxing.WriterException;
 import com.google.zxing.qrcode.QRCodeWriter;
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
 import net.glxn.qrgen.core.AbstractQRCode;
 import net.glxn.qrgen.core.exception.QRGenerationException;
+import net.glxn.qrgen.core.image.ImageType;
 import net.glxn.qrgen.core.vcard.VCard;
 
 import java.io.File;
@@ -59,8 +62,62 @@ public class QRCode extends AbstractQRCode {
      * @param vcard the vcard to encode as QRCode
      * @return the QRCode object
      */
-    public static AbstractQRCode from(VCard vcard) {
+    public static QRCode from(VCard vcard) {
         return new QRCode(vcard.toString());
+    }
+
+    /**
+     * Overrides the imageType from its default {@link net.glxn.qrgen.core.image.ImageType#PNG}
+     *
+     * @param imageType the {@link net.glxn.qrgen.core.image.ImageType} you would like the resulting QR to be
+     * @return the current QRCode object
+     */
+    public QRCode to(ImageType imageType) {
+        this.imageType = imageType;
+        return this;
+    }
+
+    /**
+     * Overrides the size of the qr from its default 125x125
+     *
+     * @param width  the width in pixels
+     * @param height the height in pixels
+     * @return the current QRCode object
+     */
+    public QRCode withSize(int width, int height) {
+        this.width = width;
+        this.height = height;
+        return this;
+    }
+
+    /**
+     * Overrides the default charset by supplying a {@link com.google.zxing.EncodeHintType#CHARACTER_SET} hint to {@link
+     * com.google.zxing.qrcode.QRCodeWriter#encode}
+     *
+     * @return the current QRCode object
+     */
+    public QRCode withCharset(String charset) {
+        return withHint(EncodeHintType.CHARACTER_SET, charset);
+    }
+
+    /**
+     * Overrides the default error correction by supplying a {@link com.google.zxing.EncodeHintType#ERROR_CORRECTION} hint to
+     * {@link com.google.zxing.qrcode.QRCodeWriter#encode}
+     *
+     * @return the current QRCode object
+     */
+    public QRCode withErrorCorrection(ErrorCorrectionLevel level) {
+        return withHint(EncodeHintType.ERROR_CORRECTION, level);
+    }
+
+    /**
+     * Sets hint to {@link com.google.zxing.qrcode.QRCodeWriter#encode}
+     *
+     * @return the current QRCode object
+     */
+    public QRCode withHint(EncodeHintType hintType, Object value) {
+        hints.put(hintType, value);
+        return this;
     }
 
     /**

--- a/android/src/test/java/net/glxn/qrgen/android/QRCodeTest.java
+++ b/android/src/test/java/net/glxn/qrgen/android/QRCodeTest.java
@@ -7,7 +7,6 @@ import com.google.zxing.Writer;
 import com.google.zxing.WriterException;
 import com.google.zxing.common.BitMatrix;
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
-import net.glxn.qrgen.core.AbstractQRCode;
 import net.glxn.qrgen.core.exception.QRGenerationException;
 import net.glxn.qrgen.core.image.ImageType;
 import net.glxn.qrgen.core.vcard.VCard;
@@ -147,7 +146,7 @@ public class QRCodeTest {
         String expected = "UTF-8";
         final Object[] capture = new Object[1];
         try {
-            final AbstractQRCode from = QRCode.from("Jour férié");
+            final QRCode from = QRCode.from("Jour férié");
             from.setQrWriter(writerWithCapture(capture));
             from.to(ImageType.PNG).withCharset(expected).stream();
         } catch (QRGenerationException ignored) {
@@ -160,7 +159,7 @@ public class QRCodeTest {
         ErrorCorrectionLevel expected = ErrorCorrectionLevel.L;
         final Object[] capture = new Object[1];
         try {
-            final AbstractQRCode from = QRCode.from("Jour férié");
+            final QRCode from = QRCode.from("Jour férié");
             from.setQrWriter(writerWithCapture(capture));
             from.to(ImageType.PNG).withErrorCorrection(ErrorCorrectionLevel.L)
                 .stream();
@@ -176,7 +175,7 @@ public class QRCodeTest {
         for (EncodeHintType type : hintTypes) {
             final Object[] capture = new Object[1];
             try {
-                final AbstractQRCode from = QRCode.from("Jour férié");
+                final QRCode from = QRCode.from("Jour férié");
                 from.setQrWriter(writerWithCapture(capture));
                 from.to(ImageType.PNG).withHint(type, expected).stream();
             } catch (QRGenerationException ignored) {

--- a/core/src/main/java/net/glxn/qrgen/core/AbstractQRCode.java
+++ b/core/src/main/java/net/glxn/qrgen/core/AbstractQRCode.java
@@ -1,20 +1,17 @@
 package net.glxn.qrgen.core;
 
+import com.google.zxing.EncodeHintType;
+import com.google.zxing.Writer;
+import com.google.zxing.WriterException;
+import com.google.zxing.common.BitMatrix;
+import net.glxn.qrgen.core.exception.QRGenerationException;
+import net.glxn.qrgen.core.image.ImageType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.HashMap;
-
-import net.glxn.qrgen.core.exception.QRGenerationException;
-import net.glxn.qrgen.core.image.ImageType;
-
-import com.google.zxing.EncodeHintType;
-import com.google.zxing.Writer;
-import com.google.zxing.WriterException;
-import com.google.zxing.common.BitMatrix;
-import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
 
 /**
  * QRCode generator. This is a simple class that is built on top of <a href="http://code.google.com/p/zxing/">ZXING</a><br/><br/>
@@ -35,60 +32,6 @@ public abstract class AbstractQRCode {
     protected int height = 125;
 
     protected ImageType imageType = ImageType.PNG;
-
-    /**
-     * Overrides the imageType from its default {@link ImageType#PNG}
-     *
-     * @param imageType the {@link ImageType} you would like the resulting QR to be
-     * @return the current QRCode object
-     */
-    public AbstractQRCode to(ImageType imageType) {
-        this.imageType = imageType;
-        return this;
-    }
-
-    /**
-     * Overrides the size of the qr from its default 125x125
-     *
-     * @param width  the width in pixels
-     * @param height the height in pixels
-     * @return the current QRCode object
-     */
-    public AbstractQRCode withSize(int width, int height) {
-        this.width = width;
-        this.height = height;
-        return this;
-    }
-
-    /**
-     * Overrides the default charset by supplying a {@link com.google.zxing.EncodeHintType#CHARACTER_SET} hint to {@link
-     * com.google.zxing.qrcode.QRCodeWriter#encode}
-     *
-     * @return the current QRCode object
-     */
-    public AbstractQRCode withCharset(String charset) {
-        return withHint(EncodeHintType.CHARACTER_SET, charset);
-    }
-
-    /**
-     * Overrides the default error correction by supplying a {@link com.google.zxing.EncodeHintType#ERROR_CORRECTION} hint to
-     * {@link com.google.zxing.qrcode.QRCodeWriter#encode}
-     *
-     * @return the current QRCode object
-     */
-    public AbstractQRCode withErrorCorrection(ErrorCorrectionLevel level) {
-        return withHint(EncodeHintType.ERROR_CORRECTION, level);
-    }
-
-    /**
-     * Sets hint to {@link com.google.zxing.qrcode.QRCodeWriter#encode}
-     *
-     * @return the current QRCode object
-     */
-    public AbstractQRCode withHint(EncodeHintType hintType, Object value) {
-        hints.put(hintType, value);
-        return this;
-    }
 
     /**
      * returns a {@link File} representation of the QR code. The file is set to be deleted on exit (i.e. {@link

--- a/core/src/main/java/net/glxn/qrgen/core/vcard/VCard.java
+++ b/core/src/main/java/net/glxn/qrgen/core/vcard/VCard.java
@@ -2,7 +2,7 @@ package net.glxn.qrgen.core.vcard;
 
 /**
  * A simple wrapper for vCard data to use with ZXing QR Code generator.
- * <p/>
+ *
  * See also http://zxing.appspot.com/generator/ and Contact Information
  *
  * @author Frederik Hahne <atomfrede@gmail.com>

--- a/javase/src/main/java/net/glxn/qrgen/javase/QRCode.java
+++ b/javase/src/main/java/net/glxn/qrgen/javase/QRCode.java
@@ -1,11 +1,14 @@
 package net.glxn.qrgen.javase;
 
+import com.google.zxing.EncodeHintType;
 import com.google.zxing.WriterException;
 import com.google.zxing.client.j2se.MatrixToImageConfig;
 import com.google.zxing.client.j2se.MatrixToImageWriter;
 import com.google.zxing.qrcode.QRCodeWriter;
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
 import net.glxn.qrgen.core.AbstractQRCode;
 import net.glxn.qrgen.core.exception.QRGenerationException;
+import net.glxn.qrgen.core.image.ImageType;
 import net.glxn.qrgen.core.vcard.VCard;
 
 import java.io.File;
@@ -22,6 +25,60 @@ public class QRCode extends AbstractQRCode {
     protected QRCode(String text) {
         this.text = text;
         qrWriter = new QRCodeWriter();
+    }
+
+    /**
+     * Overrides the imageType from its default {@link net.glxn.qrgen.core.image.ImageType#PNG}
+     *
+     * @param imageType the {@link net.glxn.qrgen.core.image.ImageType} you would like the resulting QR to be
+     * @return the current QRCode object
+     */
+    public QRCode to(ImageType imageType) {
+        this.imageType = imageType;
+        return this;
+    }
+
+    /**
+     * Overrides the size of the qr from its default 125x125
+     *
+     * @param width  the width in pixels
+     * @param height the height in pixels
+     * @return the current QRCode object
+     */
+    public QRCode withSize(int width, int height) {
+        this.width = width;
+        this.height = height;
+        return this;
+    }
+
+    /**
+     * Overrides the default charset by supplying a {@link com.google.zxing.EncodeHintType#CHARACTER_SET} hint to {@link
+     * com.google.zxing.qrcode.QRCodeWriter#encode}
+     *
+     * @return the current QRCode object
+     */
+    public QRCode withCharset(String charset) {
+        return withHint(EncodeHintType.CHARACTER_SET, charset);
+    }
+
+    /**
+     * Overrides the default error correction by supplying a {@link com.google.zxing.EncodeHintType#ERROR_CORRECTION} hint to
+     * {@link com.google.zxing.qrcode.QRCodeWriter#encode}
+     *
+     * @return the current QRCode object
+     */
+    public QRCode withErrorCorrection(ErrorCorrectionLevel level) {
+        return withHint(EncodeHintType.ERROR_CORRECTION, level);
+    }
+
+    /**
+     * Sets hint to {@link com.google.zxing.qrcode.QRCodeWriter#encode}
+     *
+     * @return the current QRCode object
+     */
+    public QRCode withHint(EncodeHintType hintType, Object value) {
+        hints.put(hintType, value);
+        return this;
     }
 
     /**
@@ -53,7 +110,7 @@ public class QRCode extends AbstractQRCode {
      * @param vcard the vcard to encode as QRCode
      * @return the QRCode object
      */
-    public static AbstractQRCode from(VCard vcard) {
+    public static QRCode from(VCard vcard) {
         return new QRCode(vcard.toString());
     }
 

--- a/javase/src/test/java/net/glxn/qrgen/javase/QRCodeTest.java
+++ b/javase/src/test/java/net/glxn/qrgen/javase/QRCodeTest.java
@@ -7,14 +7,16 @@ import com.google.zxing.Writer;
 import com.google.zxing.WriterException;
 import com.google.zxing.common.BitMatrix;
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
-import net.glxn.qrgen.core.AbstractQRCode;
 import net.glxn.qrgen.core.exception.QRGenerationException;
 import net.glxn.qrgen.core.image.ImageType;
 import net.glxn.qrgen.core.vcard.VCard;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Map;
 
@@ -23,6 +25,18 @@ public class QRCodeTest {
     @Test
     public void shouldGetSvgFromText() throws Exception {
         File file = QRCode.from("www.example.org").svg();
+        Assert.assertNotNull(file);
+    }
+
+    @Test
+    public void shouldGetSvgWithSizeFromText() throws Exception {
+        File file = QRCode.from("www.example.com").withSize(250, 250).svg();
+        Assert.assertNotNull(file);
+    }
+
+    @Test
+    public void shouldGetSvgWithSizeAndColorFromText() {
+        File file = QRCode.from("www.example.com").withSize(250, 250).withColor(30, 90).svg();
         Assert.assertNotNull(file);
     }
 
@@ -161,7 +175,7 @@ public class QRCodeTest {
         String expected = "UTF-8";
         final Object[] capture = new Object[1];
         try {
-            final AbstractQRCode from = QRCode.from("Jour férié");
+            final QRCode from = QRCode.from("Jour férié");
             from.setQrWriter(writerWithCapture(capture));
             from.to(ImageType.PNG).withCharset(expected).stream();
         } catch (QRGenerationException ignored) {
@@ -174,7 +188,7 @@ public class QRCodeTest {
         ErrorCorrectionLevel expected = ErrorCorrectionLevel.L;
         final Object[] capture = new Object[1];
         try {
-            final AbstractQRCode from = QRCode.from("Jour férié");
+            final QRCode from = QRCode.from("Jour férié");
             from.setQrWriter(writerWithCapture(capture));
             from.to(ImageType.PNG).withErrorCorrection(ErrorCorrectionLevel.L).stream();
         } catch (QRGenerationException ignored) {
@@ -189,7 +203,7 @@ public class QRCodeTest {
         for (EncodeHintType type : hintTypes) {
             final Object[] capture = new Object[1];
             try {
-                final AbstractQRCode from = QRCode.from("Jour férié");
+                final QRCode from = QRCode.from("Jour férié");
                 from.setQrWriter(writerWithCapture(capture));
                 from.to(ImageType.PNG).withHint(type, expected).stream();
             } catch (QRGenerationException ignored) {


### PR DESCRIPTION
* both bitmap (on android) and svg (on javase) can be used with size, color, hint and so on
* therefore a little code duplication, but it makes the api more concise (in my opinion)

Update #40