### PR TITLE
Zxing version 3.3.0 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     </modules>
 
     <properties>
-        <zxing.version>3.1.0</zxing.version>
+        <zxing.version>3.3.0</zxing.version>
         <junit.version>4.8.2</junit.version>
         <robolectric.version>2.2</robolectric.version>
         <fest-android.version>1.0.7</fest-android.version>


### PR DESCRIPTION
Current version of QRGen 2.2.0 uses Zxing version 3.1.0
https://github.com/kenglxn/QRGen/blob/2.2.0/pom.xml#L47

Unfortunately that version does not support images with alpha channels/transparency even though the QRGen readme mentions alpha channels.

When creating the image colour model Zxing 3.1.0 will always return  plain RGB:
https://github.com/zxing/zxing/blob/zxing-3.1.0/javase/src/main/java/com/google/zxing/client/j2se/MatrixToImageConfig.java#L59

But from version 3.3.0 it can return ARGB:
https://github.com/zxing/zxing/blob/zxing-3.3.0/javase/src/main/java/com/google/zxing/client/j2se/MatrixToImageConfig.java#L64

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kenglxn/qrgen/87)
<!-- Reviewable:end -->
