### PR TITLE
Update Url.java

### DIFF
--- a/core/src/main/java/net/glxn/qrgen/core/scheme/Url.java
+++ b/core/src/main/java/net/glxn/qrgen/core/scheme/Url.java
@@ -17,7 +17,7 @@ public class Url extends Schema {
 
 	public String getUrl() {
 		if (url != null) {
-			return url.toString().toUpperCase();
+			return url.toString();
 		}
 		return null;
 	}


### PR DESCRIPTION
The Url is forced to upperCase() which is not correct. Some url may contain combination of both small and uppercase letters.