### PR TITLE
Allow schema implementation in user projects

### DIFF
--- a/core/src/main/java/net/glxn/qrgen/core/scheme/Schema.java
+++ b/core/src/main/java/net/glxn/qrgen/core/scheme/Schema.java
@@ -7,10 +7,6 @@ package net.glxn.qrgen.core.scheme;
  */
 public abstract class Schema {
 
-	Schema() {
-		super();
-	}
-
 	/**
 	 * Parse qr code schema for given code string.
 	 * 


### PR DESCRIPTION
I removed the package-private constructor to allow lib users to create their own Schema implementations.