### PR TITLE
Make `createMatrix` public

### DIFF
--- a/core/src/main/java/net/glxn/qrgen/core/AbstractQRCode.java
+++ b/core/src/main/java/net/glxn/qrgen/core/AbstractQRCode.java
@@ -82,7 +82,7 @@ public abstract class AbstractQRCode {
 
     protected abstract void writeToStream(OutputStream stream) throws IOException, WriterException;
 
-    protected BitMatrix createMatrix(String text) throws WriterException {
+    public BitMatrix createMatrix(String text) throws WriterException {
         return qrWriter.encode(text, com.google.zxing.BarcodeFormat.QR_CODE, width, height, hints);
     }
 


### PR DESCRIPTION
Make `createMatrix` public to make more possibilities

#121 