### PR TITLE
Upgrade zxing version to newest possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     </modules>
 
     <properties>
-        <zxing.version>3.3.0</zxing.version>
+        <zxing.version>3.4.0</zxing.version>
         <batik.version>1.10</batik.version>
         <junit.version>4.8.2</junit.version>
         <robolectric.version>2.2</robolectric.version>


### PR DESCRIPTION
zxing in version 3.3.0 contains vulnerability that can end up in Buffer Overflow: https://ossindex.sonatype.org/vuln/80d18c11-c2d5-481c-ae03-809b865aa715

zxing in version 3.4.0 seems to have upgraded imageio library and no longer exposes this vulnerability.